### PR TITLE
Skarlsso/lp 10 cleanup build warnings on osx

### DIFF
--- a/ground/openpilotgcs/openpilotgcs.pri
+++ b/ground/openpilotgcs/openpilotgcs.pri
@@ -233,3 +233,13 @@ win32 {
     # The ((packet)) pragma is used in uav metadata struct and other places
     QMAKE_CXXFLAGS += -mno-ms-bitfields
 }
+
+# Stricter warnigs turned on for OS X.
+macx {
+    CONFIG += warn_on
+    !warn_off {
+        QMAKE_CXXFLAGS_WARN_ON += -Werror
+        QMAKE_CFLAGS_WARN_ON   += -Werror
+        QMAKE_CXXFLAGS_WARN_ON += -Wno-gnu-static-float-init
+    }
+}

--- a/ground/openpilotgcs/src/app/main.cpp
+++ b/ground/openpilotgcs/src/app/main.cpp
@@ -301,6 +301,7 @@ inline QStringList getPluginPaths()
     QStringList rc;
 
     QString pluginPath = QApplication::applicationDirPath();
+
     pluginPath += QLatin1Char('/');
     pluginPath += QLatin1String(PLUGIN_REL_PATH);
     rc.push_back(pluginPath);

--- a/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/SSP/port.cpp
+++ b/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/SSP/port.cpp
@@ -27,7 +27,7 @@
 #include "port.h"
 #include "delay.h"
 #include <QDebug>
-port::port(QString name, bool debug) : mstatus(port::closed), debug(debug)
+port::port(QString name, bool debug) : debug(debug), mstatus(port::closed)
 {
     timer.start();
     sport = new QSerialPort();

--- a/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/main.cpp
+++ b/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/main.cpp
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
             }
             QByteArray fw;
             dfu.DownloadFirmware(&fw, 0);
-            bool ret    = dfu.SaveByteArrayToFile(file.toLatin1(), fw);
+            bool ret = dfu.SaveByteArrayToFile(file.toLatin1(), fw);
             return ret;
         } else if (action == OP_DFU::actionCompareCrc) {
             dfu.CompareFirmware(file.toLatin1(), OP_DFU::crccompare, device);

--- a/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/main.cpp
+++ b/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/main.cpp
@@ -191,9 +191,9 @@ int main(int argc, char *argv[])
                     return -1;
                 }
             } else if (!description.isEmpty()) {
-                retstatus = dfu.UploadDescription(description);
-                if (retstatus != OP_DFU::Last_operation_Success) {
-                    standardOutput << "Upload failed with code:" << retstatus << endl;
+                OP_DFU::Status status = dfu.UploadDescription(description);
+                if (status != OP_DFU::Last_operation_Success) {
+                    standardOutput << "Upload failed with code:" << status << endl;
                     return -1;
                 }
             }
@@ -206,7 +206,6 @@ int main(int argc, char *argv[])
                 standardOutput << "ERROR device not readable\n" << endl;
                 return false;
             }
-            qint32 size = ((OP_DFU::device)dfu.devices[device]).SizeOfCode;
             QByteArray fw;
             dfu.DownloadFirmware(&fw, 0);
             bool ret    = dfu.SaveByteArrayToFile(file.toLatin1(), fw);

--- a/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/op_dfu.cpp
+++ b/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/op_dfu.cpp
@@ -1111,8 +1111,8 @@ int DFUObject::receiveData(void *data, int size)
                 qDebug() << "____timeout";
             }
             if (x > size - 1) {
-              qDebug() << "Error buffer overrun";
-              Q_ASSERT(false);
+                qDebug() << "Error buffer overrun";
+                Q_ASSERT(false);
             }
             return x;
         }

--- a/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/op_dfu.cpp
+++ b/ground/openpilotgcs/src/experimental/USB_UPLOAD_TOOL/op_dfu.cpp
@@ -346,7 +346,7 @@ OP_DFU::Status DFUObject::UploadDescription(QVariant desc)
     cout << "Starting uploading description\n";
     QByteArray array;
 
-    if (desc.type() == QMetaType::QString) {
+    if (desc.type() == QVariant::String) {
         QString description = desc.toString();
         if (description.length() % 4 != 0) {
             int pad = description.length() / 4;
@@ -357,7 +357,7 @@ OP_DFU::Status DFUObject::UploadDescription(QVariant desc)
             description.append(padding);
         }
         array = description.toLatin1();
-    } else if (desc.type() == QMetaType::QByteArray) {
+    } else if (desc.type() == QVariant::ByteArray) {
         array = desc.toByteArray();
     }
 
@@ -1109,6 +1109,10 @@ int DFUObject::receiveData(void *data, int size)
             msleep(10);
             if (time.elapsed() > 10000) {
                 qDebug() << "____timeout";
+            }
+            if (x > size - 1) {
+              qDebug() << "Error buffer overrun";
+              Q_ASSERT(false);
             }
             return x;
         }

--- a/ground/openpilotgcs/src/libs/opmapcontrol/src/common.pri
+++ b/ground/openpilotgcs/src/libs/opmapcontrol/src/common.pri
@@ -8,3 +8,10 @@ UI_DIR = uics
 MOC_DIR = mocs
 OBJECTS_DIR = objs
 INCLUDEPATH +=../../../../libs/
+
+# Stricter warnings turned on for OS X.
+macx {
+    CONFIG += warn_on
+    QMAKE_CXXFLAGS_WARN_ON += -Werror
+    QMAKE_CFLAGS_WARN_ON   += -Werror
+}

--- a/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
+++ b/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
@@ -487,7 +487,7 @@ QString UrlFactory::MakeReverseGeocoderUrl(internals::PointLatLng &pt, const QSt
 #ifdef DEBUG_URLFACTORY
     qDebug() << "Language: " << language;
 #else
-	(void)language;
+	Q_UNUSED(language);
 #endif
     // CSV output has been depreciated. API key is no longer needed.
     return QString("http://maps.googleapis.com/maps/api/geocode/xml?latlng=%1,%2").arg(QString::number(pt.Lat())).arg(QString::number(pt.Lng()));

--- a/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
+++ b/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
@@ -486,6 +486,8 @@ QString UrlFactory::MakeReverseGeocoderUrl(internals::PointLatLng &pt, const QSt
 {
 #ifdef DEBUG_URLFACTORY
     qDebug() << "Language: " << language;
+#else
+	(void)language;
 #endif
     // CSV output has been depreciated. API key is no longer needed.
     return QString("http://maps.googleapis.com/maps/api/geocode/xml?latlng=%1,%2").arg(QString::number(pt.Lat())).arg(QString::number(pt.Lng()));

--- a/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
+++ b/ground/openpilotgcs/src/libs/opmapcontrol/src/core/urlfactory.cpp
@@ -487,7 +487,7 @@ QString UrlFactory::MakeReverseGeocoderUrl(internals::PointLatLng &pt, const QSt
 #ifdef DEBUG_URLFACTORY
     qDebug() << "Language: " << language;
 #else
-	Q_UNUSED(language);
+    Q_UNUSED(language);
 #endif
     // CSV output has been depreciated. API key is no longer needed.
     return QString("http://maps.googleapis.com/maps/api/geocode/xml?latlng=%1,%2").arg(QString::number(pt.Lat())).arg(QString::number(pt.Lng()));

--- a/ground/openpilotgcs/src/libs/qwt/qwt.pro
+++ b/ground/openpilotgcs/src/libs/qwt/qwt.pro
@@ -17,9 +17,6 @@ include( qwtconfig.pri )
 TEMPLATE = subdirs
 CONFIG   += ordered
 
-# disable all warnings (no need for warnings as qwt sources are imported)
-CONFIG += warn_off
-
 SUBDIRS = \
     src \
 #    textengines \

--- a/ground/openpilotgcs/src/libs/qwt/src/src.pro
+++ b/ground/openpilotgcs/src/libs/qwt/src/src.pro
@@ -35,6 +35,9 @@ DEFINES           += QWT_LIBRARY
 #
 include(../../../openpilotgcslibrary.pri)
 
+# disable all warnings (no need for warnings as qwt sources are imported)
+CONFIG += warn_off
+
 contains(QWT_CONFIG, QwtDll) {
 
     CONFIG += dll

--- a/ground/openpilotgcs/src/libs/utils/pathutils.cpp
+++ b/ground/openpilotgcs/src/libs/utils/pathutils.cpp
@@ -41,6 +41,7 @@ namespace Utils {
 QString GetDataPath()
 {
     QString dataPath = QApplication::applicationDirPath();
+
     dataPath += QLatin1Char('/');
     dataPath += QLatin1String(DATA_REL_PATH);
     dataPath += QLatin1Char('/');

--- a/ground/openpilotgcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/config/cfg_vehicletypes/configmultirotorwidget.cpp
@@ -787,7 +787,7 @@ QString ConfigMultiRotorWidget::updateConfigObjectsFromWidgets()
 
             // Tricopter : Yaw mix slider value applies to servo (was fixed)
             // Get absolute MixerValueYaw, no servo reverse when Reverse All Motors is checked
-            setMixerVectorValue(mixer, channel, VehicleConfig::MIXERVECTOR_YAW, abs(getMixerValue(mixer, "MixerValueYaw")) * 1.27);
+            setMixerVectorValue(mixer, channel, VehicleConfig::MIXERVECTOR_YAW, abs(int(getMixerValue(mixer, "MixerValueYaw"))) * 1.27);
         }
 
         m_aircraft->mrStatusLabel->setText(tr("Configuration OK"));

--- a/ground/openpilotgcs/src/plugins/coreplugin/coreconstants.h
+++ b/ground/openpilotgcs/src/plugins/coreplugin/coreconstants.h
@@ -129,7 +129,7 @@ const char *const GO_FORWARD              = "GCS.GoForward";
 const char *const GOTOPREVIOUSGROUP       = "GCS.GotoPreviousTabGroup";
 const char *const GOTONEXTGROUP           = "GCS.GotoNextTabGroup";
 const char *const WINDOWSLIST             = "GCS.WindowsList";
-const char *const ABOUT_LIBREPILOTGCS      = "GCS.AboutLibrePilotGCS";
+const char *const ABOUT_LIBREPILOTGCS     = "GCS.AboutLibrePilotGCS";
 const char *const ABOUT_PLUGINS           = "GCS.AboutPlugins";
 const char *const ABOUT_AUTHORS           = "GCS.AboutAuthors";
 const char *const ABOUT_QT                = "GCS.AboutQt";
@@ -212,7 +212,7 @@ const char *const ICON_PLUGIN         = ":/core/images/pluginicon.png";
 const char *const ICON_EXIT           = ":/core/images/exiticon.png";
 const char *const ICON_OPTIONS        = ":/core/images/optionsicon.png";
 const char *const ICON_HELP           = ":/core/images/helpicon.png";
-const char *const ICON_LIBREPILOT      = ":/core/images/librepiloticon.png";
+const char *const ICON_LIBREPILOT     = ":/core/images/librepiloticon.png";
 
 
 // wizard kind

--- a/ground/openpilotgcs/src/plugins/coreplugin/generalsettings.cpp
+++ b/ground/openpilotgcs/src/plugins/coreplugin/generalsettings.cpp
@@ -279,7 +279,7 @@ bool GeneralSettings::useExpertMode() const
     return m_useExpertMode;
 }
 
-bool GeneralSettings::setCollectUsageData(bool collect)
+void GeneralSettings::setCollectUsageData(bool collect)
 {
     if (collect && collect != m_collectUsageData) {
         setShowUsageDataDisclaimer(true);
@@ -287,7 +287,7 @@ bool GeneralSettings::setCollectUsageData(bool collect)
     m_collectUsageData = collect;
 }
 
-bool GeneralSettings::setShowUsageDataDisclaimer(bool show)
+void GeneralSettings::setShowUsageDataDisclaimer(bool show)
 {
     m_showUsageDataDisclaimer = show;
 }

--- a/ground/openpilotgcs/src/plugins/coreplugin/generalsettings.h
+++ b/ground/openpilotgcs/src/plugins/coreplugin/generalsettings.h
@@ -63,8 +63,8 @@ public:
     void readSettings(QSettings *qs);
     void saveSettings(QSettings *qs);
     bool useExpertMode() const;
-    bool setCollectUsageData(bool collect);
-    bool setShowUsageDataDisclaimer(bool show);
+    void setCollectUsageData(bool collect);
+    void setShowUsageDataDisclaimer(bool show);
     void setLastUsageHash(QString hash);
 
 private slots:

--- a/ground/openpilotgcs/src/plugins/coreplugin/mainwindow.cpp
+++ b/ground/openpilotgcs/src/plugins/coreplugin/mainwindow.cpp
@@ -289,6 +289,7 @@ QString MainWindow::loadStyleSheet(QString fileName)
     QString style;
     // ...to open the file
     QFile file(Utils::GetDataPath() + QString("stylesheets/") + fileName);
+
     qDebug() << "Loading style sheet file" << file.fileName();
     if (file.open(QFile::ReadOnly)) {
         // QTextStream...

--- a/ground/openpilotgcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
+++ b/ground/openpilotgcs/src/plugins/coreplugin/uavgadgetmanager/uavgadgetmanager.cpp
@@ -71,11 +71,6 @@ using namespace Utils;
 
 enum { debugUAVGadgetManager = 0 };
 
-static inline ExtensionSystem::PluginManager *pluginManager()
-{
-    return ExtensionSystem::PluginManager::instance();
-}
-
 // ===================UAVGadgetManager=====================
 
 UAVGadgetManager::UAVGadgetManager(ICore *core, QString name, QIcon icon, int priority, QString uniqueName, QWidget *parent) :

--- a/ground/openpilotgcs/src/plugins/dial/dialgadgetwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/dial/dialgadgetwidget.cpp
@@ -558,7 +558,7 @@ void DialGadgetWidget::rotateNeedles()
     int dialRun = 3;
     if (n2enabled) {
         double needle2Diff;
-        if (abs((needle2Value - needle2Target) * 10) > 5 && beSmooth) {
+        if (abs(int((needle2Value - needle2Target) * 10)) > 5 && beSmooth) {
             needle2Diff = (needle2Target - needle2Value) / 5;
         } else {
             needle2Diff = needle2Target - needle2Value;
@@ -590,7 +590,7 @@ void DialGadgetWidget::rotateNeedles()
 
     // We assume that needle1 always exists!
     double needle1Diff;
-    if ((abs((needle1Value - needle1Target) * 10) > 5) && beSmooth) {
+    if ((abs(int((needle1Value - needle1Target) * 10)) > 5) && beSmooth) {
         needle1Diff = (needle1Target - needle1Value) / 5;
     } else {
         needle1Diff = needle1Target - needle1Value;
@@ -614,7 +614,7 @@ void DialGadgetWidget::rotateNeedles()
 
     if (n3enabled) {
         double needle3Diff;
-        if ((abs((needle3Value - needle3Target) * 10) > 5) && beSmooth) {
+        if ((abs(int((needle3Value - needle3Target) * 10)) > 5) && beSmooth) {
             needle3Diff = (needle3Target - needle3Value) / 5;
         } else {
             needle3Diff = needle3Target - needle3Value;

--- a/ground/openpilotgcs/src/plugins/dial/dialgadgetwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/dial/dialgadgetwidget.cpp
@@ -29,6 +29,7 @@
 #include "dialgadgetwidget.h"
 #include <utils/stylehelper.h>
 #include <iostream>
+#include <math.h>
 #include <QtOpenGL/QGLWidget>
 #include <QDebug>
 
@@ -558,7 +559,7 @@ void DialGadgetWidget::rotateNeedles()
     int dialRun = 3;
     if (n2enabled) {
         double needle2Diff;
-        if (abs(int((needle2Value - needle2Target) * 10)) > 5 && beSmooth) {
+        if (beSmooth && fabs(needle2Value - needle2Target) > 0.5) {
             needle2Diff = (needle2Target - needle2Value) / 5;
         } else {
             needle2Diff = needle2Target - needle2Value;
@@ -590,7 +591,7 @@ void DialGadgetWidget::rotateNeedles()
 
     // We assume that needle1 always exists!
     double needle1Diff;
-    if ((abs(int((needle1Value - needle1Target) * 10)) > 5) && beSmooth) {
+    if (beSmooth && fabs(needle1Value - needle1Target) > 0.5) {
         needle1Diff = (needle1Target - needle1Value) / 5;
     } else {
         needle1Diff = needle1Target - needle1Value;
@@ -614,7 +615,7 @@ void DialGadgetWidget::rotateNeedles()
 
     if (n3enabled) {
         double needle3Diff;
-        if ((abs(int((needle3Value - needle3Target) * 10)) > 5) && beSmooth) {
+        if (beSmooth && fabs(needle3Value - needle3Target) > 0.5) {
             needle3Diff = (needle3Target - needle3Value) / 5;
         } else {
             needle3Diff = needle3Target - needle3Value;

--- a/ground/openpilotgcs/src/plugins/lineardial/lineardialgadgetwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/lineardial/lineardialgadgetwidget.cpp
@@ -426,7 +426,7 @@ void LineardialGadgetWidget::moveIndex()
         dialTimer.stop();
         return;
     }
-    if ((abs((indexValue - indexTarget) * 10) > 3)) {
+    if ((abs(int((indexValue - indexTarget) * 10)) > 3)) {
         indexValue += (indexTarget - indexValue) / 5;
     } else {
         indexValue = indexTarget;

--- a/ground/openpilotgcs/src/plugins/ophid/hidapi/mac/hid.c
+++ b/ground/openpilotgcs/src/plugins/ophid/hidapi/mac/hid.c
@@ -252,7 +252,7 @@ static int get_string_property(IOHIDDeviceRef device, CFStringRef prop, wchar_t 
 			len * sizeof(wchar_t),
 			&used_buf_len);
 
-		if (chars_copied == len)
+		if ((size_t)chars_copied == len)
 			buf[len] = 0; /* len is decremented above */
 		else
 			buf[chars_copied] = 0;
@@ -292,7 +292,7 @@ static int get_string_property_utf8(IOHIDDeviceRef device, CFStringRef prop, cha
 			len,
 			&used_buf_len);
 
-		if (used_buf_len == len)
+		if ((size_t)used_buf_len == len)
 			buf[len] = 0; /* len is decremented above */
 		else
 			buf[used_buf_len] = 0;

--- a/ground/openpilotgcs/src/plugins/ophid/ophid.pro
+++ b/ground/openpilotgcs/src/plugins/ophid/ophid.pro
@@ -46,6 +46,10 @@ macx {
         hidapi/mac/hid.c
 
     LIBS += -framework CoreFoundation -framework IOKit
+
+    # hid.c has too many warnings about unused paramters.
+    QMAKE_CXXFLAGS_WARN_ON += -Wno-unused-parameter
+    QMAKE_CFLAGS_WARN_ON   += -Wno-unused-parameter
 }
 
 linux {

--- a/ground/openpilotgcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
+++ b/ground/openpilotgcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
@@ -156,7 +156,7 @@ void opmap_edit_waypoint_dialog::setupModeWidgets()
         ui->dsb_modeParam3->setVisible(false);
         ui->dsb_modeParam4->setVisible(false);
         break;
-	 case MapDataDelegate::MODE_AUTOTAKEOFF:
+    case MapDataDelegate::MODE_AUTOTAKEOFF:
         // FIXME: Do nothing?
         break;
     }

--- a/ground/openpilotgcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
+++ b/ground/openpilotgcs/src/plugins/opmap/opmap_edit_waypoint_dialog.cpp
@@ -156,6 +156,9 @@ void opmap_edit_waypoint_dialog::setupModeWidgets()
         ui->dsb_modeParam3->setVisible(false);
         ui->dsb_modeParam4->setVisible(false);
         break;
+	 case MapDataDelegate::MODE_AUTOTAKEOFF:
+        // FIXME: Do nothing?
+        break;
     }
 }
 void opmap_edit_waypoint_dialog::setupConditionWidgets()

--- a/ground/openpilotgcs/src/plugins/opmap/opmapgadget.cpp
+++ b/ground/openpilotgcs/src/plugins/opmap/opmapgadget.cpp
@@ -45,7 +45,7 @@ void OPMapGadget::saveDefaultLocation(double lng, double lat, double zoom)
         m_config->setLatitude(lat);
         m_config->setLongitude(lng);
         m_config->setZoom(zoom);
-        m_config->saveConfig();
+        m_config->save();
     }
 }
 

--- a/ground/openpilotgcs/src/plugins/opmap/opmapgadgetconfiguration.cpp
+++ b/ground/openpilotgcs/src/plugins/opmap/opmapgadgetconfiguration.cpp
@@ -105,23 +105,13 @@ IUAVGadgetConfiguration *OPMapGadgetConfiguration::clone()
 
     return m;
 }
-void OPMapGadgetConfiguration::saveConfig() const
+void OPMapGadgetConfiguration::save() const
 {
     if (!m_settings) {
         return;
     }
-    m_settings->setValue("mapProvider", m_mapProvider);
-    m_settings->setValue("defaultZoom", m_defaultZoom);
-    m_settings->setValue("defaultLatitude", m_defaultLatitude);
-    m_settings->setValue("defaultLongitude", m_defaultLongitude);
-    m_settings->setValue("useOpenGL", m_useOpenGL);
-    m_settings->setValue("showTileGridLines", m_showTileGridLines);
-    m_settings->setValue("accessMode", m_accessMode);
-    m_settings->setValue("useMemoryCache", m_useMemoryCache);
-    m_settings->setValue("uavSymbol", m_uavSymbol);
-    m_settings->setValue("cacheLocation", Utils::RemoveStoragePath(m_cacheLocation));
-    m_settings->setValue("maxUpdateRate", m_maxUpdateRate);
-    m_settings->setValue("overlayOpacity", m_opacity);
+
+    saveConfig(m_settings);
 }
 void OPMapGadgetConfiguration::saveConfig(QSettings *qSettings) const
 {

--- a/ground/openpilotgcs/src/plugins/opmap/opmapgadgetconfiguration.h
+++ b/ground/openpilotgcs/src/plugins/opmap/opmapgadgetconfiguration.h
@@ -101,7 +101,7 @@ public:
     {
         return m_opacity;
     }
-    void saveConfig() const;
+    void save() const;
 public slots:
     void setMapProvider(QString provider)
     {

--- a/ground/openpilotgcs/src/plugins/scope/scopegadgetwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/scope/scopegadgetwidget.cpp
@@ -391,7 +391,7 @@ void ScopeGadgetWidget::addCurvePlot(QString objectName, QString fieldPlusSubFie
                                           meanSamples, mathFunction, m_plotDataSize,
                                           pen, antialiased);
     } else {
-      Q_ASSERT(m_plotType == ChronoPlot);
+        Q_ASSERT(m_plotType == ChronoPlot);
         plotData = new ChronoPlotData(object, field, element, scaleFactor,
                                       meanSamples, mathFunction, m_plotDataSize,
                                       pen, antialiased);

--- a/ground/openpilotgcs/src/plugins/scope/scopegadgetwidget.cpp
+++ b/ground/openpilotgcs/src/plugins/scope/scopegadgetwidget.cpp
@@ -390,7 +390,8 @@ void ScopeGadgetWidget::addCurvePlot(QString objectName, QString fieldPlusSubFie
         plotData = new SequentialPlotData(object, field, element, scaleFactor,
                                           meanSamples, mathFunction, m_plotDataSize,
                                           pen, antialiased);
-    } else if (m_plotType == ChronoPlot) {
+    } else {
+      Q_ASSERT(m_plotType == ChronoPlot);
         plotData = new ChronoPlotData(object, field, element, scaleFactor,
                                       meanSamples, mathFunction, m_plotDataSize,
                                       pen, antialiased);

--- a/ground/openpilotgcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/openpilotgcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -98,7 +98,7 @@ bool VehicleConfigurationHelper::setupHardwareSettings(bool save)
     return result;
 }
 
-bool VehicleConfigurationHelper::isApplicable(UAVObject *dataObj)
+bool VehicleConfigurationHelper::isApplicable(UAVObject * /* dataObj */)
 {
     return true;
 }

--- a/ground/openpilotgcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
+++ b/ground/openpilotgcs/src/plugins/setupwizard/vehicleconfigurationhelper.cpp
@@ -98,8 +98,9 @@ bool VehicleConfigurationHelper::setupHardwareSettings(bool save)
     return result;
 }
 
-bool VehicleConfigurationHelper::isApplicable(UAVObject * /* dataObj */)
+bool VehicleConfigurationHelper::isApplicable(UAVObject *dataObj)
 {
+    Q_UNUSED(dataObj);
     return true;
 }
 

--- a/ground/openpilotgcs/src/plugins/setupwizard/vehicletemplateexportdialog.cpp
+++ b/ground/openpilotgcs/src/plugins/setupwizard/vehicletemplateexportdialog.cpp
@@ -50,7 +50,7 @@
 
 const char *VehicleTemplateExportDialog::EXPORT_FIXEDWING_NAME = "fixedwing";
 const char *VehicleTemplateExportDialog::EXPORT_MULTI_NAME     = "multirotor";
-const char *VehicleTemplateExportDialog::EXPORT_HELI_NAME      = "helicopter";
+const char *VehicleTemplateExportDialog::EXPORT_HELI_NAME = "helicopter";
 const char *VehicleTemplateExportDialog::EXPORT_SURFACE_NAME   = "surface";
 const char *VehicleTemplateExportDialog::EXPORT_CUSTOM_NAME    = "custom";
 

--- a/ground/openpilotgcs/src/plugins/usagetracker/usagetrackerplugin.cpp
+++ b/ground/openpilotgcs/src/plugins/usagetracker/usagetrackerplugin.cpp
@@ -164,16 +164,16 @@ void UsageTrackerPlugin::collectUsageParameters(QMap<QString, QString> &paramete
         parameters["board_type"]   = "0x" + QString::number(boardModel, 16).toLower();
         parameters["board_serial"] = utilMngr->getBoardCPUSerial().toHex();
         parameters["bl_version"]   = QString::number(utilMngr->getBootloaderRevision());
-        parameters["fw_tag"] = devDesc.gitTag;
-        parameters["fw_hash"] = devDesc.gitHash;
+        parameters["fw_tag"]      = devDesc.gitTag;
+        parameters["fw_hash"]     = devDesc.gitHash;
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-        parameters["os_version"]   = QSysInfo::prettyProductName() + " " + QSysInfo::currentCpuArchitecture();
+        parameters["os_version"]  = QSysInfo::prettyProductName() + " " + QSysInfo::currentCpuArchitecture();
 #else
-        parameters["os_version"]   = "none";
+        parameters["os_version"]  = "none";
 #endif
-        parameters["os_threads"]   = QString::number(QThread::idealThreadCount());
-        parameters["os_timezone"]  = QTimeZone::systemTimeZoneId();
-        parameters["gcs_version"]  = VersionInfo::revision();
+        parameters["os_threads"]  = QString::number(QThread::idealThreadCount());
+        parameters["os_timezone"] = QTimeZone::systemTimeZoneId();
+        parameters["gcs_version"] = VersionInfo::revision();
 
         // Configuration parameters
         ExtensionSystem::PluginManager *pm = ExtensionSystem::PluginManager::instance();


### PR DESCRIPTION
Please, review these patches to clean up the the warnings when compiling GCS on OS X. The patch also turns on `-Wall` and `-Werror` where applicable. There are some libraries that have been imported into the code base, that produce warnings. Those warnings are muted by specifying `CONFIG += warn_off` in the libraries' *.pro files.

There are one or two bugs unveiled that we might want to consider creating new bug reports for. Most prominent, is the the unguarded memcpy in the ophid code.