### PR TITLE
LP-37 Fix alignment bug in in pvPortMallocGeneric

### DIFF
--- a/flight/pios/common/libraries/FreeRTOS/Source/portable/MemMang/heap_1.c
+++ b/flight/pios/common/libraries/FreeRTOS/Source/portable/MemMang/heap_1.c
@@ -103,7 +103,7 @@ static uint8_t *pucAlignedHeap = NULL;
 size_t mask = alignment - 1;
 	/* Ensure that blocks are always aligned to the required number of bytes. */
 	#if portBYTE_ALIGNMENT != 1
-		if( xWantedSize & portBYTE_ALIGNMENT_MASK )
+		if( xWantedSize & mask )
 		{
 			/* Byte alignment required. */
 		    xWantedSize += ( alignment - ( xWantedSize & mask ) );


### PR DESCRIPTION
The allocation size was incremented by 'alignment' bytes when
'xWantedSize' was 'alignment' aligned, but not 'portBYTE_ALIGNMENT'
aligned.